### PR TITLE
Add 'src' prop allow to load inline SVG from XML string

### DIFF
--- a/src/D3SvgFileZoomPan.js
+++ b/src/D3SvgFileZoomPan.js
@@ -43,15 +43,19 @@ class D3SvgFileEngine {
   }
 
   processSvgFile(props, svgFrame) {
-    d3.xml(props.svgPath, (error, svgFile) => {
-      if (error) {
-        console.warn(error);
-        return;
-      }
-      if (svgFile) {
-        this.attachSvgFile(svgFile, svgFrame, props.resize);
-      }
-    });
+    if (props.svg) {
+      svgFrame.node().appendChild(props.svg);
+    } else {
+      d3.xml(props.svgPath, (error, svgFile) => {
+        if (error) {
+          console.warn(error);
+          return;
+        }
+        if (svgFile) {
+          this.attachSvgFile(svgFile, svgFrame, props.resize);
+        }
+      });
+    }
   }
 
   attachSvgFile(svgFile, svgFrame, resize) {

--- a/src/SvgFileZoomPan.js
+++ b/src/SvgFileZoomPan.js
@@ -6,6 +6,7 @@ export default class SvgFileZoomPan extends React.Component {
   componentDidMount() {
     D3SvgFileZoomPan.create({
       svgPath: this.props.svgPath,
+      svg: this.props.svg,
       duration: this.props.duration,
       resize: this.props.resize,
       el: this.getDOMNode(),
@@ -15,6 +16,7 @@ export default class SvgFileZoomPan extends React.Component {
   componentWillReceiveProps(nextProps) {
     D3SvgFileZoomPan.update({
       svgPath: nextProps.svgPath,
+      svg: nextProps.svg,
       duration: this.props.duration,
       resize: nextProps.resize,
       el: this.getDOMNode(),
@@ -38,6 +40,7 @@ export default class SvgFileZoomPan extends React.Component {
 
 SvgFileZoomPan.propTypes = {
   svgPath: React.PropTypes.string,
+  svg: React.PropTypes.string,
   duration: React.PropTypes.number,
   resize: React.PropTypes.bool,
 };


### PR DESCRIPTION
Add `src` prop so that we can use this component to load inline SVG string like `react-svg-inline`.